### PR TITLE
[BUGFIX] Lösche doppeltes meta-Element für Sprach-Spezifikation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,6 @@
         </title>
         <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
         <meta http-equiv="robots" content="index,follow,all"/>
-        <meta http-equiv="content-language" content="de"/>
         <meta name="description"
               content="Spiele und Methoden für Workshops, Seminare, Erstsemestereinführungen oder einfach so zum Spaß;"/>
         <meta name="keywords"


### PR DESCRIPTION
Lösche doppeltes meta-Element für Sprach-Spezifikation,

weil: "file:/github/workspace/./public/index.html":10.9-10.58: error: Using the "meta" element to specify the document-wide default language is obsolete. Consider specifying the language on the root element instead."